### PR TITLE
fix: Update package.json with correct type path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "umd:main": "dist/umd/index.js",
-  "types": "dist/types/index.d.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",


### PR DESCRIPTION
The types weren't showing up in my IDE correctly, and I saw that the `types` property in `package.json` had the wrong extension.